### PR TITLE
feat: integrate OpenAI for slogan generation and update brand kit pro…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "ioredis": "^5.8.1",
         "next": "^15.5.3",
         "nodemailer": "^7.0.6",
+        "openai": "^6.7.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "stripe": "^18.5.0",
@@ -9807,6 +9808,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.7.0.tgz",
+      "integrity": "sha512-mgSQXa3O/UXTbA8qFzoa7aydbXBJR5dbLQXCRapAOtoNT+v69sLdKMZzgiakpqhclRnhPggPAXoniVGn2kMY2A==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -12383,8 +12405,9 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ioredis": "^5.8.1",
     "next": "^15.5.3",
     "nodemailer": "^7.0.6",
+    "openai": "^6.7.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "stripe": "^18.5.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,7 +65,9 @@ model BrandKit {
     user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
     title     String
     status    BrandKitStatus @default(PENDING)
+    outputs   Json
 }
+
 
 enum BrandKitStatus {
     PENDING

--- a/src/app/results/[id]/page.tsx
+++ b/src/app/results/[id]/page.tsx
@@ -31,6 +31,7 @@ const ResultsPage = async ({ params }: ResultsPageProps) => {
 
             <Box bgColor='base-100' padding='6' className='rounded-lg max-w-sm'>
                 <Text>Status: {brandKit.status}</Text>
+                <Text>Outputs: {JSON.stringify(brandKit.outputs)}</Text>
             </Box>
         </Stack>
     );

--- a/src/components/NewBrandKitForm.tsx
+++ b/src/components/NewBrandKitForm.tsx
@@ -31,7 +31,12 @@ const NewBrandKitForm = () => {
                 return;
             }
 
-            const createdBrandKitId = await startGenerateBrandKitJob(session.user.id, "New Brand Kit");
+            const formData = new FormData(e.currentTarget);
+
+            const createdBrandKitId = await startGenerateBrandKitJob({
+                userId: session.user.id,
+                title: formData.get('businessName') as string,
+            });
 
             router.push(`/results/${createdBrandKitId}`)
 
@@ -68,6 +73,7 @@ const NewBrandKitForm = () => {
                 >
                     <InputField
                         type="text"
+                        name="businessName"
                         placeholder="Enter your business name"
                         fullWidth
                         required

--- a/src/lib/ai/openai.ts
+++ b/src/lib/ai/openai.ts
@@ -1,0 +1,28 @@
+import serverEnv from "@/lib/env/serverEnv";
+import OpenAI from "openai";
+
+export const openaiClient = new OpenAI({ apiKey: serverEnv.OPENAI_API_KEY });
+
+export const generateSlogan = async (businessName: string): Promise<string> => {
+    
+    const openai = openaiClient;
+
+    const prompt = `Generate a catchy slogan for a business named "${businessName}". Keep it under 10 words.`;
+
+    console.log("Generating slogan with prompt:", prompt);
+
+    const response = await openai.chat.completions.create({
+        model: "gpt-3.5-turbo",
+        messages: [
+            { role: "system", content: "You are a creative marketing assistant." },
+            { role: "user", content: prompt }
+        ],
+        max_tokens: 50,
+        temperature: 0.7,
+    });
+
+    console.log("Slogan generated:", response.choices[0].message.content);
+
+    return response.choices[0].message.content || "";
+
+}

--- a/src/lib/dal/brandkits.ts
+++ b/src/lib/dal/brandkits.ts
@@ -2,13 +2,15 @@ import prisma from "@/db/db";
 import { BrandKitStatus } from "../../../generated/prisma";
 import { checkServerAuth } from "@/lib/auth/server/session";
 import { headers } from "next/headers";
+import { JsonObject } from "@prisma/client/runtime/library";
 
 export const createBrandKit = async (userId: string, title: string) => {
 
     const createdBrandKit = await prisma.brandKit.create({
         data: {
             userId,
-            title
+            title,
+            outputs: {}
         }
     });
 
@@ -16,14 +18,15 @@ export const createBrandKit = async (userId: string, title: string) => {
 
 }
 
-export const updateBrandKit = async (brandKitId: string, status: BrandKitStatus) => {
+export const updateBrandKit = async (brandKitId: string, status: BrandKitStatus, outputs: JsonObject) => {
 
     const updatedBrandKit = await prisma.brandKit.update({
         where: {
             id: brandKitId
         },
         data: {
-            status
+            status,
+            outputs
         }
     });
 

--- a/src/lib/env/serverEnv.ts
+++ b/src/lib/env/serverEnv.ts
@@ -21,6 +21,8 @@ const serverSchema = z.object({
     EMAIL_FROM: z.email(),
     // REDIS
     REDIS_URL: z.string().min(1),
+    // OPENAI
+    OPENAI_API_KEY: z.string().min(1),
 })
 
 const _server = serverSchema.safeParse(process.env);

--- a/src/lib/queue/actions.ts
+++ b/src/lib/queue/actions.ts
@@ -3,18 +3,16 @@
 import { createBrandKit } from "@/lib/dal/brandkits"
 import { GENERATE_BRANDKIT_JOB_NAME } from "@/lib/queue/const"
 import { brandkitQueue } from "@/lib/queue/queue"
-import { generateBrandKitJobDataSchema } from "@/lib/queue/schemas"
+import { BrandKitRequestData, BrandKitRequestDataSchema } from "@/lib/queue/schemas"
 
-export const startGenerateBrandKitJob = async (userId: string, title: string) => {
+export const startGenerateBrandKitJob = async (data : unknown) => {
 
-    const data = generateBrandKitJobDataSchema.parse({
-        userId,
-        title,
-    })
+    const parsedData: BrandKitRequestData = BrandKitRequestDataSchema.parse(data)
 
-    const createdBrandKit = await createBrandKit(data.userId, data.title)
+    const createdBrandKit = await createBrandKit(parsedData.userId, parsedData.title)
 
     await brandkitQueue.add(GENERATE_BRANDKIT_JOB_NAME, {
+        ...parsedData,
         brandKitId: createdBrandKit.id
     })
 

--- a/src/lib/queue/schemas.ts
+++ b/src/lib/queue/schemas.ts
@@ -1,8 +1,8 @@
 import z from "zod";
 
-export const generateBrandKitJobDataSchema = z.object({
+export const BrandKitRequestDataSchema = z.object({
     userId: z.string().min(1),
     title: z.string().min(1),
 })
 
-export type GenerateBrandKitJobData = z.infer<typeof generateBrandKitJobDataSchema>;
+export type BrandKitRequestData = z.infer<typeof BrandKitRequestDataSchema>;

--- a/src/lib/worker/brandkit.worker.ts
+++ b/src/lib/worker/brandkit.worker.ts
@@ -1,6 +1,8 @@
+import { generateSlogan } from "@/lib/ai/openai";
 import { updateBrandKit } from "@/lib/dal/brandkits";
 import serverEnv from "@/lib/env/serverEnv";
 import { BRANDKIT_QUEUE_NAME } from "@/lib/queue/const";
+import { BrandKitRequestData } from "@/lib/queue/schemas";
 import { Worker } from "bullmq";
 import IORedis from "ioredis";
 
@@ -12,25 +14,68 @@ const connection = new IORedis(serverEnv.REDIS_URL, {
 console.log("Starting BrandKit worker...");
 
 const worker = new Worker(BRANDKIT_QUEUE_NAME, async job => {
-    console.log("Processing job:", job.id);
 
-    const { brandKitId } = job.data
-    
-    const createdBrandKit = await updateBrandKit(brandKitId, "COMPLETED")
-    
-    console.log("Brand kit complete:", createdBrandKit.id);
-    
-    return createdBrandKit;
-}, { 
-    connection, 
-    concurrency: 3 
+    const startTime = Date.now()
+    let brandKitId: string | undefined
+
+    try {
+
+        console.log("Processing job:", job.id);
+
+        const data: BrandKitRequestData & { brandKitId: string } = job.data;
+
+        if (!data.brandKitId) {
+            throw new Error("Missing brandKitId in job data");
+        }
+
+        if (!data.title?.trim()) {
+            throw new Error("Missing or empty title in job data");
+        }
+
+        brandKitId = data.brandKitId;
+
+        const slogan = await generateSlogan(data.title);
+
+        if (!slogan?.trim()) {
+            throw new Error("Failed to generate slogan - empty result");
+        }
+
+        const createdBrandKit = await updateBrandKit(
+            data.brandKitId,
+            "COMPLETED",
+            {
+                "0": slogan
+            }
+        );
+
+        const duration = Date.now() - startTime;
+        console.log(`✅ Brand kit complete: ${createdBrandKit.id} (${duration}ms)`);
+
+        return createdBrandKit;
+
+    } catch (error) {
+        console.error("Error processing job:", job.id, error);
+
+        if (brandKitId) {
+            await updateBrandKit(
+                brandKitId,
+                "FAILED",
+                {}
+            );
+        }
+        throw error;
+    }
+
+}, {
+    connection,
+    concurrency: 3
 });
 
-worker.on('completed', job => { 
+worker.on('completed', job => {
     console.log(`✅ Job ${job.id} has completed!`);
 });
 
-worker.on('failed', (job, err) => { 
+worker.on('failed', (job, err) => {
     console.log(`❌ Job ${job?.id} has failed with ${err.message}`);
     console.error(err);
 });


### PR DESCRIPTION
…cessing

This pull request introduces foundational AI-powered slogan generation for the BrandKit feature, integrating OpenAI, updating the data model, and improving the job processing and form handling. The most important changes are grouped below:

**AI Integration & Slogan Generation**
* Added the `openai` package and implemented `generateSlogan` in `src/lib/ai/openai.ts` to generate a business slogan using OpenAI's API. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R34) [[2]](diffhunk://#diff-ded681ac366d895f8b67a3d79cf909b53680e2f9adb67d12a050e8fc3f3bb788R1-R28)
* The BrandKit worker (`src/lib/worker/brandkit.worker.ts`) now calls `generateSlogan` during job processing and saves the result to the database. It also handles errors and updates the status accordingly. [[1]](diffhunk://#diff-a6671aad29b68f01f28bb14b25173f6ecea6b1c7b517b6393750a0127192e3f0R1-R5) [[2]](diffhunk://#diff-a6671aad29b68f01f28bb14b25173f6ecea6b1c7b517b6393750a0127192e3f0R17-R68)

**Data Model & Schema Updates**
* Extended the `BrandKit` model in `prisma/schema.prisma` to include an `outputs` field for storing AI-generated results.
* Updated DAL methods in `src/lib/dal/brandkits.ts` to support the new `outputs` field for creation and updates.
* Added `OPENAI_API_KEY` to the server environment schema in `src/lib/env/serverEnv.ts`.

**Job Queue & Type Refinement**
* Refactored job queue schemas and types: replaced `generateBrandKitJobDataSchema` with `BrandKitRequestDataSchema` and updated queue action signatures for type safety and flexibility. [[1]](diffhunk://#diff-da6a195f121a8a40146807e3b78c8b270b9061b5716bfa4a67505401c056bdafL6-R15) [[2]](diffhunk://#diff-1a01c7e5e60fbeefdc8194339aaa135c4867186b7ff19612453cba2b518930c4L3-R8)

**Frontend Improvements**
* Updated the BrandKit creation form (`src/components/NewBrandKitForm.tsx`) to collect a business name and pass it to the backend, aligning with the new job schema. [[1]](diffhunk://#diff-e5e201574c003ad891d54b4bddbb7ff3b04fee57527450c52290011685c19cb7L34-R39) [[2]](diffhunk://#diff-e5e201574c003ad891d54b4bddbb7ff3b04fee57527450c52290011685c19cb7R76)
* On the results page, now displays the generated outputs (slogan) for each BrandKit. ([src/app/results/[id]/page.tsxR34](diffhunk://#diff-177ff61e1c4e64fefedc84b7cd4f27eb1e0abb701b11ac2a46793126dbfdac9cR34))