### PR TITLE
feat: Add token deduction and transaction handling for brand kit comp…

### DIFF
--- a/src/lib/dal/brandkits.ts
+++ b/src/lib/dal/brandkits.ts
@@ -1,5 +1,5 @@
 import prisma from "@/db/db";
-import { BrandKit, BrandKitStatus } from "../../../generated/prisma";
+import { BrandKit, BrandKitStatus, TokenTransaction, User } from "../../../generated/prisma";
 import { checkServerAuth } from "@/lib/auth/server/session";
 import { headers } from "next/headers";
 import { JsonObject, InputJsonValue } from "@prisma/client/runtime/library";
@@ -19,7 +19,7 @@ export const createBrandKit = async (userId: string, title: string): Promise<Bra
 }
 
 export const updateBrandKitById = async (
-    brandKitId: string, 
+    brandKitId: string,
     updates: Partial<Omit<BrandKit, "id" | "userId">>
 ): Promise<BrandKit> => {
 
@@ -63,5 +63,55 @@ export const getAllBrandKitsByUserId = async (userId: string): Promise<BrandKit[
     });
 
     return brandKits;
+
+}
+
+/**
+ * Completes a brand kit by updating its status and outputs, deducts tokens from the user,
+ * and creates a token transaction record. All operations are performed atomically in a single transaction.
+ *
+ * @param brandKitId - The ID of the brand kit to complete.
+ * @param outputs - The outputs to associate with the completed brand kit.
+ * @param userId - The ID of the user whose tokens will be deducted.
+ * @param tokenCost - The number of tokens to deduct from the user.
+ * @returns A Promise resolving to a tuple containing:
+ *   [0] The updated BrandKit,
+ *   [1] The updated User (with tokens deducted),
+ *   [2] The created TokenTransaction record.
+ * All operations are performed in a single transaction; if any step fails, no changes are applied.
+ */
+export const completeBrandKitWithTokenDeduction = async (brandKitId: string, outputs: BrandKit["outputs"], userId: string, tokensConsumed: number): Promise<[
+    BrandKit,
+    User,
+    TokenTransaction
+]> => {
+
+
+    return await prisma.$transaction([
+        // Update BrandKit status and outputs
+        prisma.brandKit.update({
+            where: {
+                id: brandKitId
+            },
+            data: {
+                status: BrandKitStatus.COMPLETED,
+                outputs
+            }
+        }),
+        // Deduct tokens from user
+        prisma.user.update({
+            where: { id: userId },
+            data: { tokens: { decrement: tokensConsumed } }
+        }),
+        // Create token transaction record
+        prisma.tokenTransaction.create({
+            data: {
+                userId,
+                type: "CONSUME",
+                tokens: tokensConsumed,
+            }
+        })
+    ])
+
 
 }

--- a/src/lib/worker/brandkit.processor.ts
+++ b/src/lib/worker/brandkit.processor.ts
@@ -1,83 +1,87 @@
 import { createBrandKitResponse } from "@/lib/ai/responses";
 import { getFrameworkBySlug } from "@/lib/dal/brandFrameworks";
-import { updateBrandKitById } from "@/lib/dal/brandkits";
+import { completeBrandKitWithTokenDeduction, updateBrandKitById } from "@/lib/dal/brandkits";
 import { deductTokensFromUser, TOKENS_PER_USD } from "@/lib/dal/tokens";
 import { BrandKitRequestData } from "@/lib/queue/schemas";
 
 export interface ProcessBrandKitJobData extends BrandKitRequestData {
-  brandKitId: string;
+    brandKitId: string;
 }
 
 export interface ProcessingResult {
-  success: boolean;
-  brandKitId: string;
-  duration: number;
-  error?: string;
+    success: boolean;
+    brandKitId: string;
+    duration: number;
+    error?: string;
 }
 
 export const processBrandKitJob = async (data: ProcessBrandKitJobData): Promise<ProcessingResult> => {
-  const startTime = Date.now();
-  
-  try {
-    console.log(`🔄 Processing BrandKit: ${data.brandKitId}`);
+    const startTime = Date.now();
 
-    // Validate required data
-    if (!data.brandKitId) {
-      throw new Error("Missing brandKitId in job data");
-    }
-
-    // Get framework
-    const framework = await getFrameworkBySlug(data.frameworkSlug);
-    if (!framework) {
-      throw new Error(`Framework not found: ${data.frameworkSlug}`);
-    }
-
-    // Generate brand kit content
-    const { output, cost } = await createBrandKitResponse(framework, data.inputs);
-
-    if (!output.sections) {
-      throw new Error("Invalid response from AI generation");
-    }
-
-    // Update brand kit with results
-    const updatedBrandKit = await updateBrandKitById(data.brandKitId, {
-      status: "COMPLETED",
-      outputs: Object.entries(output.sections).map(([title, content]) => ({ 
-        title, 
-        content 
-      }))
-    });
-
-    // deduct token cost from user's balance
-    await deductTokensFromUser(data.userId, Math.ceil(cost * TOKENS_PER_USD))
-
-    const duration = Date.now() - startTime;
-    console.log(`✅ BrandKit completed: ${updatedBrandKit.id} (${duration}ms)`);
-
-    return {
-      success: true,
-      brandKitId: data.brandKitId,
-      duration
-    };
-
-  } catch (error) {
-    const duration = Date.now() - startTime;
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    
-    console.error(`❌ BrandKit failed: ${data.brandKitId} (${duration}ms)`, errorMessage);
-
-    // Update brand kit status to failed
     try {
-      await updateBrandKitById(data.brandKitId, { status: "FAILED" });
-    } catch (updateError) {
-      console.error('Failed to update BrandKit status to FAILED:', updateError);
-    }
+        console.log(`🔄 Processing BrandKit: ${data.brandKitId}`);
 
-    return {
-      success: false,
-      brandKitId: data.brandKitId,
-      duration,
-      error: errorMessage
-    };
-  }
+        // Validate required data
+        if (!data.brandKitId) {
+            throw new Error("Missing brandKitId in job data");
+        }
+
+        // Get framework
+        const framework = await getFrameworkBySlug(data.frameworkSlug);
+        if (!framework) {
+            throw new Error(`Framework not found: ${data.frameworkSlug}`);
+        }
+
+        // Generate brand kit content
+        const response = await createBrandKitResponse(framework, data.inputs);
+
+        if (!response.output.sections) {
+            throw new Error("Invalid response from AI generation");
+        }
+
+        // Prepare outputs
+        const brandKitOutputs = Object.entries(response.output.sections).map(([title, content]) => ({
+            title,
+            content
+        }));
+
+        const tokensConsumed = Math.ceil(response.cost * TOKENS_PER_USD);
+
+        // Complete brand kit with token deduction transaction
+        const [updatedBrandKit, updatedUser, tokenTransaction] = await completeBrandKitWithTokenDeduction(
+            data.brandKitId,
+            brandKitOutputs,
+            data.userId,
+            tokensConsumed
+        );
+
+        const duration = Date.now() - startTime;
+        console.log(`BrandKit completed: ${data.brandKitId} in ${duration}ms, Tokens used: ${tokensConsumed}, Token Transaction ID: ${tokenTransaction.id}`);
+
+        return {
+            success: true,
+            brandKitId: data.brandKitId,
+            duration
+        };
+
+    } catch (error) {
+        const duration = Date.now() - startTime;
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+        console.error(`❌ BrandKit failed: ${data.brandKitId} (${duration}ms)`, errorMessage);
+
+        // Update brand kit status to failed
+        try {
+            await updateBrandKitById(data.brandKitId, { status: "FAILED" });
+        } catch (updateError) {
+            console.error('Failed to update BrandKit status to FAILED:', updateError);
+        }
+
+        return {
+            success: false,
+            brandKitId: data.brandKitId,
+            duration,
+            error: errorMessage
+        };
+    }
 }


### PR DESCRIPTION
…letion

This pull request introduces an important improvement to the brand kit completion workflow by ensuring that updating the brand kit, deducting user tokens, and recording the token transaction are all performed atomically in a single database transaction. This prevents inconsistencies if any part of the process fails. The changes also refactor the worker logic to use this new atomic operation.

**Atomic brand kit completion and token deduction:**

* Added a new function `completeBrandKitWithTokenDeduction` in `brandkits.ts` that updates the brand kit's status and outputs, deducts tokens from the user, and creates a token transaction record, all within a single atomic transaction.
* Updated the brand kit processing logic in `brandkit.processor.ts` to use the new atomic function, ensuring that all related operations succeed or fail together and logging relevant transaction details.

**Code maintenance and imports:**

* Updated imports in `brandkits.ts` and `brandkit.processor.ts` to include the new function and required types. [[1]](diffhunk://#diff-daa1f3e565f8a434d224021cb36aff2ffd7908fc5a3418353b23544ab90d1bcfL2-R2) [[2]](diffhunk://#diff-d7cf30a2f43e5d9a7471a79b633d10b20d050f9b435cf76591c78171722a9984L3-R3)