### PR TITLE
feat: Enhance MongoDB setup and initialization for local development …

### DIFF
--- a/.github/prompts/notion-create-task.prompt.md
+++ b/.github/prompts/notion-create-task.prompt.md
@@ -1,7 +1,7 @@
 ---
 agent: 'agent'
 model: Claude Sonnet 4
-tools: ['runCommands', 'edit', 'search', 'notionApi/*', 'usages', 'vscodeAPI', 'problems', 'changes', 'openSimpleBrowser', 'githubRepo']
+tools: ['execute/getTerminalOutput', 'execute/runInTerminal', 'read/terminalLastCommand', 'read/terminalSelection', 'edit', 'search', 'notionApi/*', 'search/usages', 'vscode/vscodeAPI', 'read/problems', 'search/changes', 'vscode/openSimpleBrowser', 'web/githubRepo']
 description: 'Project-agnostic Notion Task Creation Assistant'
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ next-env.d.ts
 *storybook.log
 storybook-static
 
-/generated/prisma
+/generated/*
 
 # playwright
 /test-results/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,27 @@
-
 services:
+  mongodb-test:
+    image: mongo:7
+    container_name: mongodb-test
+    command: ["/bin/sh", "/docker-entrypoint-initdb.d/mongodb-init.sh"]
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=test
+    volumes:
+      - ./mongodb-init.sh:/docker-entrypoint-initdb.d/mongodb-init.sh:ro
+      - ../generated/mongodb-test-keyfile:/data/keyfile
+    ports:
+      - "27017:27017"
+    networks:
+      - app-network
+    profiles:
+      - test
+    healthcheck:
+      test: mongosh --username admin --password test --authenticationDatabase admin --quiet --eval "db.adminCommand('ping')"
+      interval: 5s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
   memory-cache:
     image: valkey/valkey:latest
     container_name: memory-cache

--- a/docker/mongodb-init.sh
+++ b/docker/mongodb-init.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -e
+
+if [ ! -f /data/db/.initialized ]; then
+  echo "First run - initializing replica set and creating admin user..."
+  mongod --replSet rs0 --bind_ip_all &
+  MONGO_PID=$!
+  
+  until mongosh --quiet --eval "db.adminCommand('ping')" > /dev/null 2>&1; do
+    echo "Waiting for MongoDB to start..."
+    sleep 1
+  done
+  
+  mongosh --quiet --eval "
+    rs.initiate({
+      _id: 'rs0',
+      members: [{_id: 0, host: 'mongodb-test:27017'}]
+    });
+  "
+  
+  sleep 2
+  
+  mongosh --quiet --eval "
+    db.getSiblingDB('admin').createUser({
+      user: 'admin',
+      pwd: 'test',
+      roles: [{role: 'root', db: 'admin'}]
+    });
+  "
+  
+  mongosh --quiet --eval "
+    use test;
+    db.createCollection('users');
+  "
+  
+  touch /data/db/.initialized
+  kill $MONGO_PID
+  wait $MONGO_PID
+  echo "Initialization complete. Starting with authentication..."
+fi
+
+chmod 400 /data/keyfile
+chown 999:999 /data/keyfile
+exec mongod --replSet rs0 --bind_ip_all --keyFile /data/keyfile

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -77,7 +77,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npx prisma generate && npm run build && npm run start',
+    command: 'npm run generate && npm run build && npm run start',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000, // 2 minutes

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+COMPOSE_PROFILE=""
+
 # Check for --test flag
 if [[ "$*" == *"--test"* ]]; then
     export NODE_ENV=test
+    COMPOSE_PROFILE="--profile test"
+    echo "--test flag detected: Starting services with ${COMPOSE_PROFILE}"
 else 
     export NODE_ENV="development"
 fi
@@ -12,19 +16,19 @@ if [ "$1" = "start" ]; then
 
     if [ "$2" = "detached" ] || [ "$3" = "detached" ]; then
 
-        ENV_FILE=../.env.$NODE_ENV.local docker compose -f docker/docker-compose.yml up -d
+        ENV_FILE=../.env.$NODE_ENV.local docker compose $COMPOSE_PROFILE -f docker/docker-compose.yml up -d
 
     else
 
-        ENV_FILE=../.env.$NODE_ENV.local docker compose -f docker/docker-compose.yml up
+        ENV_FILE=../.env.$NODE_ENV.local docker compose $COMPOSE_PROFILE -f docker/docker-compose.yml up
 
     fi
 elif [ "$1" = "stop" ]; then
 
-    docker compose -f docker/docker-compose.yml down
+    docker compose $COMPOSE_PROFILE -f docker/docker-compose.yml down
 
 elif [ "$1" = "build" ]; then
 
-    docker compose -f docker/docker-compose.yml build
+    docker compose $COMPOSE_PROFILE -f docker/docker-compose.yml build
 
 fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
+
+mkdir -p generated
+openssl rand -base64 756 > generated/mongodb-test-keyfile
+chmod 400 generated/mongodb-test-keyfile
+
 npm run build-services
 
-npm run start-services detached
+npm run start-services -- detached --test
 
 docker build -t brandkitpilot-playwright -f ./docker/Dockerfile.playwright .
 docker run -it --rm --init --ipc=host --network=host -v $PWD:/app -v /app/node_modules -v /app/generated -w /app --env-file .env.test.local -e NODE_ENV=test brandkitpilot-playwright npx playwright test
 
-npm run stop-services
+npm run stop-services -- --test


### PR DESCRIPTION
…environment

This pull request introduces a new test MongoDB service to the development environment and updates related scripts to support test-specific service profiles. The changes enable easier automated testing with a properly initialized and secured MongoDB replica set, while streamlining service startup and shutdown for both development and test environments.

**Docker: Test MongoDB Service Integration**
* Added a `mongodb-test` service to `docker/docker-compose.yml` for test environments, including replica set initialization, admin user creation, keyfile setup, and healthcheck configuration.
* Created `docker/mongodb-init.sh` to automate MongoDB replica set initialization, admin user setup, test database and collection creation, and keyfile permissions.
* Updated `scripts/test.sh` to generate a secure keyfile for MongoDB, ensure proper permissions, and use the new test profile for starting/stopping services.

**Service Script Improvements**
* Modified `scripts/services.sh` to detect the `--test` flag, set the appropriate Docker Compose profile, and pass it to all service commands (`start`, `stop`, `build`). [[1]](diffhunk://#diff-985ca65c2253b80af787ea38fbff9233caff1d534f0560b1cc02dbf43961d45cR3-R9) [[2]](diffhunk://#diff-985ca65c2253b80af787ea38fbff9233caff1d534f0560b1cc02dbf43961d45cL15-R32)

**Other Updates**
* Updated the Playwright config to use `npm run generate` instead of `npx prisma generate` before running tests, aligning with the new service setup.
* Refined the tool list in `.github/prompts/notion-create-task.prompt.md` for more granular control and naming consistency.