### PR TITLE
feat: implement title persistence and polling for brand kit generation

### DIFF
--- a/docs/BrandKitPilot/systems/brandKitGeneration.md
+++ b/docs/BrandKitPilot/systems/brandKitGeneration.md
@@ -63,6 +63,10 @@ The parsed response shape:
 }
 ```
 
+### Title Persistence and Polling
+
+The AI-generated `title` is persisted to the database when the job completes via `completeBrandKitWithTokenDeduction`. When a user waits on the `/results/:id` page for generation to finish, the client polls using `getBrandKitStatus`, which returns `{ status, outputs, title }`. The `ResultsPageClient` updates its local state with the new title when the status changes to `COMPLETED`, so the user sees the AI-generated title without needing to refresh the page.
+
 ## **Token Cost Calculation**
 
 After a successful API call, the actual USD cost is calculated from the usage data returned by OpenAI (`input_tokens`, `cached_tokens`, `output_tokens`) using per-model pricing defined in `utils.ts`. The cost is converted to in-app tokens using the conversion rate `TOKENS_PER_USD` and deducted atomically from the user's balance alongside saving the outputs.

--- a/docs/data-access-layer.md
+++ b/docs/data-access-layer.md
@@ -181,6 +181,7 @@ Credentials are URL-encoded to handle special characters. `DATABASE_ARGS` is the
 | `updateBrandKitById(brandKitId, updates)` | No | Partially updates a brand kit by ID. Protects `id` and `userId` from modification via `Omit`. |
 | `getBrandKitById(brandKitId)` | Yes (session) | Fetches a single brand kit by its ID. |
 | `getAllBrandKitsByUserId(userId)` | Yes (session + ownership) | Fetches all brand kits for a user. Validates that the session user matches the requested `userId`. |
+| `getBrandKitStatus(brandKitId)` | Yes (session + ownership) | Returns `{ status, outputs, title }` for polling. Validates ownership before returning data. |
 | `getBrandKitForExport(brandKitId)` | Yes (session + ownership) | Fetches a brand kit for export. Returns `null` if not found, not owned by user, or not `COMPLETED`. |
 | `completeBrandKitWithTokenDeduction(...)` | No | Atomic transaction: updates brand kit to `COMPLETED`, deducts tokens from user, and logs a transaction. |
 

--- a/src/app/results/[id]/BrandKitResultsPoller.tsx
+++ b/src/app/results/[id]/BrandKitResultsPoller.tsx
@@ -10,11 +10,13 @@ import Badge from '@/components/Badge/Badge';
 import { BrandKitStatus } from "@/generated/prisma";
 import { getBrandKitStatus } from "@/lib/dal/brandkits";
 
+type BrandKitOutput = { title: string; content: string };
+
 interface BrandKitResultsPollerProps {
     brandKitId: string;
     initialStatus: BrandKitStatus;
     initialTitle: string;
-    onStatusChange: (status: BrandKitStatus, outputs: any[]) => void;
+    onStatusChange: (status: BrandKitStatus, outputs: BrandKitOutput[], title: string) => void;
 }
 
 /**
@@ -80,7 +82,7 @@ export default function BrandKitResultsPoller({
                 // Check if status has changed
                 if (result.status !== status) {
                     setStatus(result.status);
-                    onStatusChange(result.status, result.outputs);
+                    onStatusChange(result.status, result.outputs, result.title);
 
                     // Stop polling if terminal state reached
                     if (result.status === "COMPLETED" || result.status === "FAILED") {

--- a/src/app/results/[id]/ResultsPageClient.tsx
+++ b/src/app/results/[id]/ResultsPageClient.tsx
@@ -132,11 +132,12 @@ const ResultsPageClient = ({ brandKit: initialBrandKit }: ResultsPageClientProps
         }
     };
 
-    const handleStatusChange = (newStatus: BrandKitStatus, outputs: any[]) => {
+    const handleStatusChange = (newStatus: BrandKitStatus, outputs: Array<{ title: string; content: string }>, title: string) => {
         setBrandKit(prev => ({
             ...prev,
             status: newStatus,
-            outputs: outputs || prev.outputs
+            outputs: outputs || prev.outputs,
+            title: title || prev.title
         }));
     };
 

--- a/src/lib/dal/brandkits.ts
+++ b/src/lib/dal/brandkits.ts
@@ -82,7 +82,7 @@ export const getAllBrandKitsByUserId = async (userId: string): Promise<BrandKit[
  *   [2] The created TokenTransaction record.
  * All operations are performed in a single transaction; if any step fails, no changes are applied.
  */
-export const completeBrandKitWithTokenDeduction = async (brandKitId: string, outputs: BrandKit["outputs"], userId: string, tokensConsumed: number): Promise<[
+export const completeBrandKitWithTokenDeduction = async (brandKitId: string, brandKitTitle: string, outputs: BrandKit["outputs"], userId: string, tokensConsumed: number): Promise<[
     BrandKit,
     User,
     TokenTransaction
@@ -96,6 +96,7 @@ export const completeBrandKitWithTokenDeduction = async (brandKitId: string, out
                 id: brandKitId
             },
             data: {
+                title: brandKitTitle,
                 status: BrandKitStatus.COMPLETED,
                 outputs
             }
@@ -119,15 +120,16 @@ export const completeBrandKitWithTokenDeduction = async (brandKitId: string, out
 }
 
 /**
- * Fetches the current status and outputs of a brand kit.
+ * Fetches the current status, title, and outputs of a brand kit.
  * Used for polling brand kit generation status on the results page.
+ * Validates that the requesting user owns the brand kit.
  * 
  * @param brandKitId - The ID of the brand kit to fetch status for
- * @returns Object containing the current status and outputs, or null if not found
+ * @returns Object containing the current status, title, and outputs, or null if not found or not owned by user
  */
-export const getBrandKitStatus = async (brandKitId: string): Promise<{ status: BrandKitStatus; outputs: BrandKit["outputs"] } | null> => {
+export const getBrandKitStatus = async (brandKitId: string): Promise<{ status: BrandKitStatus; outputs: BrandKit["outputs"]; title: string } | null> => {
 
-    await checkServerAuth(headers)
+    const session = await checkServerAuth(headers)
 
     const brandKit = await prisma.brandKit.findUnique({
         where: {
@@ -135,11 +137,20 @@ export const getBrandKitStatus = async (brandKitId: string): Promise<{ status: B
         },
         select: {
             status: true,
-            outputs: true
+            outputs: true,
+            title: true,
+            userId: true
         }
     });
 
-    return brandKit;
+    // Return null if not found or not owned by requesting user
+    if (!brandKit || brandKit.userId !== session.user.id) {
+        return null;
+    }
+
+    // Don't expose userId in return
+    const { userId, ...result } = brandKit;
+    return result;
 
 }
 

--- a/src/lib/worker/brandkit.processor.ts
+++ b/src/lib/worker/brandkit.processor.ts
@@ -50,6 +50,7 @@ export const processBrandKitJob = async (data: ProcessBrandKitJobData): Promise<
         // Complete brand kit with token deduction transaction
         const [updatedBrandKit, updatedUser, tokenTransaction] = await completeBrandKitWithTokenDeduction(
             data.brandKitId,
+            response.output.title || "New Brand Kit",
             brandKitOutputs,
             data.userId,
             tokensConsumed


### PR DESCRIPTION
This pull request improves the persistence and polling of AI-generated brand kit titles, ensuring that users see the correct title on the results page without needing to refresh. It also enhances backend security by validating ownership when fetching brand kit status and updates the data access layer and client-side code to support these changes.

**Backend persistence and API improvements:**

* The `completeBrandKitWithTokenDeduction` function now saves the AI-generated `title` to the database when a brand kit job completes, ensuring the title is persisted for later retrieval. [[1]](diffhunk://#diff-daa1f3e565f8a434d224021cb36aff2ffd7908fc5a3418353b23544ab90d1bcfL85-R85) [[2]](diffhunk://#diff-daa1f3e565f8a434d224021cb36aff2ffd7908fc5a3418353b23544ab90d1bcfR99) [[3]](diffhunk://#diff-d7cf30a2f43e5d9a7471a79b633d10b20d050f9b435cf76591c78171722a9984R53)
* The `getBrandKitStatus` function now returns the `title` in addition to `status` and `outputs`, and validates that the requesting user owns the brand kit before returning data, increasing security and data integrity.

**Client-side polling and state management:**

* The polling logic in `BrandKitResultsPoller` and the handler in `ResultsPageClient` have been updated to receive and propagate the `title` field, so the UI updates the displayed title as soon as generation is complete. ([src/app/results/[id]/BrandKitResultsPoller.tsxR13-R19](diffhunk://#diff-963e4b946bed3242d430cd61a3e6d905596c10704ec2ecd3e457b07de9bdb082R13-R19), [src/app/results/[id]/BrandKitResultsPoller.tsxL83-R85](diffhunk://#diff-963e4b946bed3242d430cd61a3e6d905596c10704ec2ecd3e457b07de9bdb082L83-R85), [src/app/results/[id]/ResultsPageClient.tsxL135-R140](diffhunk://#diff-44866c197590399bf6fd9460b597e70e8fbd59c511efe1f7164fdbe67c1817e3L135-R140))

**Documentation updates:**

* The data access layer documentation and the brand kit generation flow documentation have been updated to reflect the new API shape and polling behavior, including the addition of the `title` field and ownership validation. [[1]](diffhunk://#diff-c1948ba99c3d4089a5ce1a853554d81bcea42c76f318cd77ec9d39f4c1f6615aR184) [[2]](diffhunk://#diff-7f85f590919692147b128e6bafa77f48afb3d9527c61b94e09e08c6d89829983R66-R69)